### PR TITLE
linux: fix compilation issue in mmGeometry

### DIFF
--- a/libs/MoMa/features/Geometry/mmGeometry.cpp
+++ b/libs/MoMa/features/Geometry/mmGeometry.cpp
@@ -209,7 +209,7 @@ arma::mat MoMa::Geometry::quatprojection(const arma::mat & a, const arma::mat & 
 		projmat.col(0) = vec1; projmat.col(1) = vec2; projmat.col(2) = vec3; projmat.col(3) = vec4;
 
 		//Compute quaternion matrix
-		quaternion quat = q.col(i);
+		quaternion quat = (vec)q.col(i);
 		mat matrix(4, 4);
 		quat.get(matrix);
 


### PR DESCRIPTION
Error message was:

  error: conversion from ‘const arma::subview_col<double>’ to non-scalar
  type ‘MoMa::quaternion’ requested
    quaternion quat = q.col(i);

Reproduced with armadillo 5.600 and 7.800, GCC 4.8, later version of GCC
may or may not be more impacted by this, but the fix is simple, so might
as well be safe.